### PR TITLE
Add createTemplate handlebars recognition

### DIFF
--- a/syntaxes/inline-hbs.json
+++ b/syntaxes/inline-hbs.json
@@ -41,6 +41,56 @@
             "include": "text.html.handlebars"
           }
         ]
+      },
+      {
+        "begin": "((createTemplate|hbs))(\\()",
+        "beginCaptures": {
+          "1": {
+            "name": "entity.name.function.ts"
+          },
+          "2": {
+            "name": "meta.function-call.ts"
+          },
+          "3": {
+            "name": "meta.brace.round.ts"
+          }
+        },
+        "end": "(\\))",
+        "endCaptures": {
+          "1": {
+            "name": "meta.brace.round.ts"
+          }
+        },
+        "patterns": [
+          {
+            "begin": "((`))",
+            "beginCaptures": {
+              "1": {
+                "name": "string.template.ts"
+              },
+              "2": {
+                "name": "punctuation.definition.string.template.begin.ts"
+              }
+            },
+            "end": "((`))",
+            "endCaptures": {
+              "1": {
+                "name": "string.template.ts"
+              },
+              "2": {
+                "name": "punctuation.definition.string.template.end.ts"
+              }
+            },
+            "patterns": [
+              {
+                "include": "text.html.handlebars"
+              }
+            ]
+          },
+          {
+            "include": "source.ts"
+          }
+        ]
       }
     ],
     "scopeName": "inline.hbs"


### PR DESCRIPTION
Adds handlebars recognition for inline template literals when using `createTemplate` from Glimmer 2.x. This also adds the highlighting for non tagged calls to `hbs` (i.e. ```hbs(`<div></div>`);```)

This works with both ways of calling `createTemplate`:

```js
createTemplate(`
  <div>
    <button>Click</button>
  </div>
`);
```

```js
createTemplate(
  { Button },
  `
    <div>
      <Button @label="click" />
    </div>
  `
);
```

Preview:
<img width="794" alt="vscode-createtemplate" src="https://user-images.githubusercontent.com/6979745/79030603-af7b9980-7b4e-11ea-9f69-5bb220e4ae8c.png">
