### PR TITLE
improve number detection

### DIFF
--- a/syntaxes/handlebars.tmLanguage.json
+++ b/syntaxes/handlebars.tmLanguage.json
@@ -179,9 +179,15 @@
       ]
     },
     "boolean": {
-      "match": "true|false|undefined|null|\\d+",
+      "match": "true|false|undefined|null|\\d*(\\.)?\\d+",
       "captures": {
         "0": {
+          "name": "string.regexp"
+        },
+        "1": {
+          "name": "string.regexp"
+        },
+        "2": {
           "name": "string.regexp"
         }
       },
@@ -282,7 +288,7 @@
     },
     "glimmer-bools": {
       "name": "entity.expression.handlebars",
-      "match": "({{~?)(true|false|null|undefined|\\d+)(~?}})",
+      "match": "({{~?)(true|false|null|undefined|\\d*(\\.)?\\d+)(~?}})",
       "captures": {
         "0": {
           "name": "keyword.operator"
@@ -294,6 +300,9 @@
           "name": "string.regexp"
         },
         "3": {
+          "name": "string.regexp"
+        },
+        "4": {
           "name": "keyword.operator"
         }
       }


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/1360552/97115862-6e259280-170a-11eb-9d59-086df57f8387.png)



after:

![image](https://user-images.githubusercontent.com/1360552/97115854-5ea64980-170a-11eb-969d-fa4e600b1135.png)


fixes https://github.com/lifeart/vsc-ember-syntax/issues/4