### PR TITLE
Make sure `<template>`s are not highlighted inside strings

### DIFF
--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -1,6 +1,6 @@
 {
   "fileTypes": ["gjs", "gts"],
-  "injectionSelector": "L:source.gjs -comment, L:source.gts -comment",
+  "injectionSelector": "L:source.gjs -comment -(string -meta.embedded), L:source.gts -comment -(string -meta.embedded)",
   "patterns": [
     {
       "name": "meta.js.embeddedTemplateWithoutArgs",


### PR DESCRIPTION
| Before | After |
|--------|-----|
|<img width="511" alt="image" src="https://github.com/lifeart/vsc-ember-syntax/assets/83799/6bc9c475-cc99-4f8d-9c05-9a5b19653547">|<img width="644" alt="image" src="https://github.com/lifeart/vsc-ember-syntax/assets/83799/c5a24aa0-1ca1-495c-bb5d-19f242148f4a">|

Resolves #42