### PR TITLE
feat: add glimmer js/ts markdown language injects

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,12 @@
           "hbs"
         ],
         "configuration": "./languages/handlebars.configuration.json"
+      },
+      {
+        "id": "markdown-gjs"
+      },
+      {
+        "id": "markdown-gts"
       }
     ],
     "grammars": [
@@ -151,6 +157,28 @@
         "path": "./syntaxes/inline.hbs.json",
         "embeddedLanguages": {
           "meta.embedded.block.html": "handlebars"
+        }
+      },
+      {
+        "language": "markdown-gjs",
+        "scopeName": "markdown.gjs.codeblock",
+        "path": "./syntaxes/markdown-gjs.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.gjs": "glimmer-js"
+        }
+      },
+      {
+        "language": "markdown-gts",
+        "scopeName": "markdown.gts.codeblock",
+        "path": "./syntaxes/markdown-gts.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.gts": "glimmer-ts"
         }
       }
     ],

--- a/syntaxes/markdown-gjs.json
+++ b/syntaxes/markdown-gjs.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#gjs-code-block"
+    }
+  ],
+  "repository": {
+    "gjs-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(gjs)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.gjs",
+          "patterns": [
+            {
+              "include": "source.gjs"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.gjs.codeblock"
+}

--- a/syntaxes/markdown-gts.json
+++ b/syntaxes/markdown-gts.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#gts-code-block"
+    }
+  ],
+  "repository": {
+    "gts-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(gts)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.gts",
+          "patterns": [
+            {
+              "include": "source.gts"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.gts.codeblock"
+}


### PR DESCRIPTION
Adds support for `gjs` and `gts` embeds in Markdown.

Based on https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example

<img width="487" alt="image" src="https://github.com/chiragpat/vscode-glimmer/assets/10243652/06cc2ef2-e575-41ba-bde7-6ecd913e75ea">

Open issue: `<template>` tag is not picked up correctly. I did some fiddling around but haven't pinpointed the exact issue. Opening the PR already just in case anyone else sees the fix.