### PR TITLE
Merge eslint validate option instead of overwriting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,10 @@ updateLanguageSettings('glimmer-js');
 updateLanguageSettings('glimmer-ts');
 
 const eslintConfig = vscode.workspace.getConfiguration('eslint');
+const validate = eslintConfig.get('validate') ?? [];
+const glimmerScopes = ['glimmer-ts', 'glimmer-js'];
 
-eslintConfig.update('validate', ['glimmer-ts', 'glimmer-js'], vscode.ConfigurationTarget.Global);
+eslintConfig.update('validate', Array.from(new Set([...validate, ...glimmerScopes])), vscode.ConfigurationTarget.Workspace);
 
 export async function activate(context: vscode.ExtensionContext) {
   const extension = vscode.extensions.getExtension(typeScriptExtensionId);


### PR DESCRIPTION
if the user already has this option set we don't want to remove their settings in favour of our own, so we merge the current options with our glimmer scopes.

Only do this in the current workspace where the addon is enabled.