### PR TITLE
Add build step to build grammars from source

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -45,6 +45,16 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: build grammars
+        run: yarn build:grammars
+
+      - name: add and commit grammars
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'syntaxes'
+          default_author: github_actions
+          message: 'chore: build grammar json files for ${{ steps.gitversion.outputs.majorMinorPatch }}'
+
       - name: update metadata in package.json
         uses: onlyutkarsh/patch-files-action@v1.0.1
         with:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "web:package": "webpack --mode production",
     "prettier": "prettier --write \"**/*.{js,ts,json,yaml}\"",
     "prettier:package": "prettier --write \"package.json\"",
-    "chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=."
+    "chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=.",
+    "build:grammars": "node ./syntaxes/src/index.mjs"
   },
   "extensionKind": [
     "ui"
@@ -99,7 +100,7 @@
     "grammars": [
       {
         "language": "glimmer-js",
-        "path": "./syntaxes/glimmer-js.json",
+        "path": "./syntaxes/source.gjs.json",
         "scopeName": "source.gjs",
         "embeddedLanguages": {
           "source.gjs": "javascript"
@@ -115,7 +116,7 @@
       },
       {
         "language": "glimmer-ts",
-        "path": "./syntaxes/glimmer-ts.json",
+        "path": "./syntaxes/source.gts.json",
         "scopeName": "source.gts",
         "embeddedLanguages": {
           "source.gts": "typescript"
@@ -133,7 +134,7 @@
         "label": "Handlebars (Ember)",
         "language": "handlebars",
         "scopeName": "text.html.ember-handlebars",
-        "path": "./syntaxes/handlebars.tmLanguage.json"
+        "path": "./syntaxes/text.html.ember-handlebars.json"
       },
       {
         "injectTo": [
@@ -141,7 +142,7 @@
           "source.ts"
         ],
         "scopeName": "inline.hbs",
-        "path": "./syntaxes/inline-hbs.json",
+        "path": "./syntaxes/inline.hbs.json",
         "embeddedLanguages": {
           "meta.embedded.block.html": "handlebars"
         }
@@ -152,7 +153,7 @@
           "source.gjs"
         ],
         "scopeName": "inline.template",
-        "path": "./syntaxes/inline-template.json",
+        "path": "./syntaxes/inline.template.json",
         "embeddedLanguages": {
           "meta.embedded.block.html": "handlebars",
           "meta.js.embeddedTemplateWithoutArgs": "handlebars",

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -1,0 +1,3 @@
+# Warning!
+
+This directory contains the compiled grammars. If you need to make modifications please edit the files found in `syntaxes/src/` and then run `yarn run build:grammars` to compile them.

--- a/syntaxes/glimmer-js.json
+++ b/syntaxes/glimmer-js.json
@@ -1,4 +1,0 @@
-{
-  "scopeName": "source.gjs",
-  "patterns": [{ "include": "source.js" }]
-}

--- a/syntaxes/glimmer-ts.json
+++ b/syntaxes/glimmer-ts.json
@@ -1,4 +1,0 @@
-{
-  "scopeName": "source.gts",
-  "patterns": [{ "include": "source.ts" }]
-}

--- a/syntaxes/inline.hbs.json
+++ b/syntaxes/inline.hbs.json
@@ -1,5 +1,8 @@
 {
-  "fileTypes": ["js", "ts"],
+  "fileTypes": [
+    "js",
+    "ts"
+  ],
   "injectionSelector": "L:source.js -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded)",
   "injections": {
     "L:source": {

--- a/syntaxes/inline.template.json
+++ b/syntaxes/inline.template.json
@@ -1,5 +1,8 @@
 {
-  "fileTypes": ["gjs", "gts"],
+  "fileTypes": [
+    "gjs",
+    "gts"
+  ],
   "injectionSelector": "L:source.gjs -comment -(string -meta.embedded), L:source.gts -comment -(string -meta.embedded)",
   "patterns": [
     {

--- a/syntaxes/source.gjs.json
+++ b/syntaxes/source.gjs.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Glimmer JS",
+  "scopeName": "source.gjs",
+  "patterns": [
+    {
+      "include": "source.js"
+    }
+  ],
+  "injections": {
+    "L:source.gjs -comment -(string -meta.embedded)": {
+      "patterns": [
+        {
+          "name": "meta.js.embeddedTemplateWithoutArgs",
+          "begin": "\\s*(<)(template)\\s*(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.ember-handlebars"
+            }
+          ]
+        },
+        {
+          "name": "meta.js.embeddedTemplateWithArgs",
+          "begin": "(<)(template)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=\\<template)",
+              "end": "(?=\\>)",
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars#tag-like-content"
+                }
+              ]
+            },
+            {
+              "begin": "(>)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.tag.end.js"
+                }
+              },
+              "end": "(?=</template>)",
+              "contentName": "meta.html.embedded.block",
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "string.js.taggedTemplate",
+          "contentName": "meta.embedded.block.html",
+          "begin": "(?x)(\\b(?:\\w+\\.)*(?:hbs|html)\\s*)(`)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.tagged-template.js"
+            },
+            "2": {
+              "name": "punctuation.definition.string.template.begin.js"
+            }
+          },
+          "end": "(`)",
+          "endCaptures": {
+            "0": {
+              "name": "string.js"
+            },
+            "1": {
+              "name": "punctuation.definition.string.template.end.js"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.ts#template-substitution-element"
+            },
+            {
+              "include": "text.html.ember-handlebars"
+            }
+          ]
+        },
+        {
+          "begin": "((createTemplate|hbs|html))(\\()",
+          "contentName": "meta.embedded.block.html",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.ts"
+            },
+            "2": {
+              "name": "meta.function-call.ts"
+            },
+            "3": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "((`))",
+              "beginCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.begin.ts"
+                }
+              },
+              "end": "((`))",
+              "endCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.end.ts"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "((precompileTemplate)\\s*)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.ts"
+            },
+            "2": {
+              "name": "meta.function-call.ts"
+            },
+            "3": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "((`|'|\"))",
+              "contentName": "meta.embedded.block.html",
+              "beginCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.begin.ts"
+                }
+              },
+              "end": "((`|'|\"))",
+              "endCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.end.ts"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            },
+            {
+              "include": "source.ts#object-literal"
+            },
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/source.gts.json
+++ b/syntaxes/source.gts.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Glimmer TS",
+  "scopeName": "source.gts",
+  "patterns": [
+    {
+      "include": "source.ts"
+    }
+  ],
+  "injections": {
+    "L:source.gts -comment -(string -meta.embedded)": {
+      "patterns": [
+        {
+          "name": "meta.js.embeddedTemplateWithoutArgs",
+          "begin": "\\s*(<)(template)\\s*(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.ember-handlebars"
+            }
+          ]
+        },
+        {
+          "name": "meta.js.embeddedTemplateWithArgs",
+          "begin": "(<)(template)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=\\<template)",
+              "end": "(?=\\>)",
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars#tag-like-content"
+                }
+              ]
+            },
+            {
+              "begin": "(>)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.tag.end.js"
+                }
+              },
+              "end": "(?=</template>)",
+              "contentName": "meta.html.embedded.block",
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "string.js.taggedTemplate",
+          "contentName": "meta.embedded.block.html",
+          "begin": "(?x)(\\b(?:\\w+\\.)*(?:hbs|html)\\s*)(`)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.tagged-template.js"
+            },
+            "2": {
+              "name": "punctuation.definition.string.template.begin.js"
+            }
+          },
+          "end": "(`)",
+          "endCaptures": {
+            "0": {
+              "name": "string.js"
+            },
+            "1": {
+              "name": "punctuation.definition.string.template.end.js"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.ts#template-substitution-element"
+            },
+            {
+              "include": "text.html.ember-handlebars"
+            }
+          ]
+        },
+        {
+          "begin": "((createTemplate|hbs|html))(\\()",
+          "contentName": "meta.embedded.block.html",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.ts"
+            },
+            "2": {
+              "name": "meta.function-call.ts"
+            },
+            "3": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "((`))",
+              "beginCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.begin.ts"
+                }
+              },
+              "end": "((`))",
+              "endCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.end.ts"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "((precompileTemplate)\\s*)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.ts"
+            },
+            "2": {
+              "name": "meta.function-call.ts"
+            },
+            "3": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.round.ts"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "((`|'|\"))",
+              "contentName": "meta.embedded.block.html",
+              "beginCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.begin.ts"
+                }
+              },
+              "end": "((`|'|\"))",
+              "endCaptures": {
+                "1": {
+                  "name": "string.template.ts"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.template.end.ts"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "text.html.ember-handlebars"
+                }
+              ]
+            },
+            {
+              "include": "source.ts#object-literal"
+            },
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/src/index.mjs
+++ b/syntaxes/src/index.mjs
@@ -49,7 +49,7 @@ if (errors.length) {
     console.log(`\n${'-'.repeat(file.length)}\n${file}\n${'-'.repeat(file.length)}`);
     console.error(error);
   }
-  process.exit(1);
+  process.exitCode = 1;
 } else {
   console.log(`\n🎉 All grammars written to ${outDirectory}`);
 }

--- a/syntaxes/src/index.mjs
+++ b/syntaxes/src/index.mjs
@@ -1,0 +1,55 @@
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import glimmerJavascript from './source.gjs.mjs';
+import glimmerTypescript from './source.gts.mjs';
+import inlineHandlebars from './inline.hbs.mjs';
+import inlineTemplate from './inline.template.mjs';
+import emberHandlebars from './text.html.ember-handlebars.mjs';
+
+const [inlineTemplateInjectionSelectorGJS, inlineTemplateInjectionSelectorGTS] =
+  inlineTemplate.injectionSelector.split(', ');
+
+glimmerJavascript.injections = {
+  [inlineTemplateInjectionSelectorGJS]: {
+    patterns: [...inlineTemplate.patterns, ...inlineHandlebars.patterns],
+  },
+};
+
+glimmerTypescript.injections = {
+  [inlineTemplateInjectionSelectorGTS]: {
+    patterns: [...inlineTemplate.patterns, ...inlineHandlebars.patterns],
+  },
+};
+
+const grammars = [glimmerJavascript, glimmerTypescript, inlineHandlebars, inlineTemplate, emberHandlebars];
+
+const outDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '../');
+
+const errors = [];
+
+console.log('Writing grammars...\n');
+
+for (const grammar of grammars) {
+  const filePath = resolve(outDirectory, `${grammar.scopeName}.json`);
+
+  try {
+    writeFileSync(filePath, JSON.stringify(grammar, null, 2));
+    console.log(`✅ ${grammar.scopeName}.json`);
+  } catch (error) {
+    console.error(`❌ ${grammar.scopeName}.json`);
+    errors.push({ file: `${grammar.scopeName}.json`, error });
+  }
+}
+
+if (errors.length) {
+  console.error(`💀 ${errors.length} grammars failed to write to ${outDirectory}`);
+  for (const { file, error } of errors) {
+    console.log(`\n${'-'.repeat(file.length)}\n${file}\n${'-'.repeat(file.length)}`);
+    console.error(error);
+  }
+  process.exit(1);
+} else {
+  console.log(`\n🎉 All grammars written to ${outDirectory}`);
+}

--- a/syntaxes/src/inline.hbs.mjs
+++ b/syntaxes/src/inline.hbs.mjs
@@ -1,0 +1,149 @@
+export default {
+  fileTypes: ['js', 'ts'],
+  injectionSelector: 'L:source.js -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded)',
+  injections: {
+    'L:source': {
+      patterns: [
+        {
+          match: '<',
+          name: 'invalid.illegal.bad-angle-bracket.html',
+        },
+      ],
+    },
+  },
+  patterns: [
+    {
+      name: 'string.js.taggedTemplate',
+      contentName: 'meta.embedded.block.html',
+      begin: '(?x)(\\b(?:\\w+\\.)*(?:hbs|html)\\s*)(`)',
+      beginCaptures: {
+        1: {
+          name: 'entity.name.function.tagged-template.js',
+        },
+        2: {
+          name: 'punctuation.definition.string.template.begin.js',
+        },
+      },
+      end: '(`)',
+      endCaptures: {
+        0: {
+          name: 'string.js',
+        },
+        1: {
+          name: 'punctuation.definition.string.template.end.js',
+        },
+      },
+      patterns: [
+        {
+          include: 'source.ts#template-substitution-element',
+        },
+        {
+          include: 'text.html.ember-handlebars',
+        },
+      ],
+    },
+    {
+      begin: '((createTemplate|hbs|html))(\\()',
+      contentName: 'meta.embedded.block.html',
+      beginCaptures: {
+        1: {
+          name: 'entity.name.function.ts',
+        },
+        2: {
+          name: 'meta.function-call.ts',
+        },
+        3: {
+          name: 'meta.brace.round.ts',
+        },
+      },
+      end: '(\\))',
+      endCaptures: {
+        1: {
+          name: 'meta.brace.round.ts',
+        },
+      },
+      patterns: [
+        {
+          begin: '((`))',
+          beginCaptures: {
+            1: {
+              name: 'string.template.ts',
+            },
+            2: {
+              name: 'punctuation.definition.string.template.begin.ts',
+            },
+          },
+          end: '((`))',
+          endCaptures: {
+            1: {
+              name: 'string.template.ts',
+            },
+            2: {
+              name: 'punctuation.definition.string.template.end.ts',
+            },
+          },
+          patterns: [
+            {
+              include: 'text.html.ember-handlebars',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      begin: '((precompileTemplate)\\s*)(\\()',
+      beginCaptures: {
+        1: {
+          name: 'entity.name.function.ts',
+        },
+        2: {
+          name: 'meta.function-call.ts',
+        },
+        3: {
+          name: 'meta.brace.round.ts',
+        },
+      },
+      end: '(\\))',
+      endCaptures: {
+        1: {
+          name: 'meta.brace.round.ts',
+        },
+      },
+      patterns: [
+        {
+          begin: '((`|\'|"))',
+          contentName: 'meta.embedded.block.html',
+          beginCaptures: {
+            1: {
+              name: 'string.template.ts',
+            },
+            2: {
+              name: 'punctuation.definition.string.template.begin.ts',
+            },
+          },
+          end: '((`|\'|"))',
+          endCaptures: {
+            1: {
+              name: 'string.template.ts',
+            },
+            2: {
+              name: 'punctuation.definition.string.template.end.ts',
+            },
+          },
+          patterns: [
+            {
+              include: 'text.html.ember-handlebars',
+            },
+          ],
+        },
+        {
+          include: 'source.ts#object-literal',
+        },
+        {
+          include: 'source.ts',
+        },
+      ],
+    },
+  ],
+  scopeName: 'inline.hbs',
+};

--- a/syntaxes/src/inline.template.mjs
+++ b/syntaxes/src/inline.template.mjs
@@ -1,0 +1,89 @@
+export default {
+  fileTypes: ['gjs', 'gts'],
+  injectionSelector: 'L:source.gjs -comment -(string -meta.embedded), L:source.gts -comment -(string -meta.embedded)',
+  patterns: [
+    {
+      name: 'meta.js.embeddedTemplateWithoutArgs',
+      begin: '\\s*(<)(template)\\s*(>)',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.definition.tag.html',
+        },
+        2: {
+          name: 'entity.name.tag.other.html',
+        },
+        3: {
+          name: 'punctuation.definition.tag.html',
+        },
+      },
+      end: '(</)(template)(>)',
+      endCaptures: {
+        1: {
+          name: 'punctuation.definition.tag.html',
+        },
+        2: {
+          name: 'entity.name.tag.other.html',
+        },
+        3: {
+          name: 'punctuation.definition.tag.html',
+        },
+      },
+      patterns: [
+        {
+          include: 'text.html.ember-handlebars',
+        },
+      ],
+    },
+    {
+      name: 'meta.js.embeddedTemplateWithArgs',
+      begin: '(<)(template)',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.definition.tag.html',
+        },
+        2: {
+          name: 'entity.name.tag.other.html',
+        },
+      },
+      end: '(</)(template)(>)',
+      endCaptures: {
+        1: {
+          name: 'punctuation.definition.tag.html',
+        },
+        2: {
+          name: 'entity.name.tag.other.html',
+        },
+        3: {
+          name: 'punctuation.definition.tag.html',
+        },
+      },
+      patterns: [
+        {
+          begin: '(?<=\\<template)',
+          end: '(?=\\>)',
+          patterns: [
+            {
+              include: 'text.html.ember-handlebars#tag-like-content',
+            },
+          ],
+        },
+        {
+          begin: '(>)',
+          beginCaptures: {
+            1: {
+              name: 'punctuation.definition.tag.end.js',
+            },
+          },
+          end: '(?=</template>)',
+          contentName: 'meta.html.embedded.block',
+          patterns: [
+            {
+              include: 'text.html.ember-handlebars',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  scopeName: 'inline.template',
+};

--- a/syntaxes/src/source.gjs.mjs
+++ b/syntaxes/src/source.gjs.mjs
@@ -1,0 +1,6 @@
+export default {
+  $schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json',
+  name: 'Glimmer JS',
+  scopeName: 'source.gjs',
+  patterns: [{ include: 'source.js' }],
+};

--- a/syntaxes/src/source.gts.mjs
+++ b/syntaxes/src/source.gts.mjs
@@ -1,0 +1,6 @@
+export default {
+  $schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json',
+  name: 'Glimmer TS',
+  scopeName: 'source.gts',
+  patterns: [{ include: 'source.ts' }],
+};

--- a/syntaxes/src/text.html.ember-handlebars.mjs
+++ b/syntaxes/src/text.html.ember-handlebars.mjs
@@ -1,0 +1,1085 @@
+export default {
+  $schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json',
+  name: 'Glimmer',
+  scopeName: 'text.html.ember-handlebars',
+  fileTypes: ['hbs'],
+  patterns: [
+    {
+      include: '#style',
+    },
+    {
+      include: '#script',
+    },
+    {
+      include: '#glimmer-else-block',
+    },
+    {
+      include: '#glimmer-bools',
+    },
+    {
+      include: '#glimmer-special-block',
+    },
+    {
+      include: '#glimmer-unescaped-expression',
+    },
+    {
+      include: '#glimmer-comment-block',
+    },
+    {
+      include: '#glimmer-comment-inline',
+    },
+    {
+      include: '#glimmer-expression-property',
+    },
+    {
+      include: '#glimmer-control-expression',
+    },
+    {
+      include: '#glimmer-expression',
+    },
+    {
+      include: '#glimmer-block',
+    },
+    {
+      include: '#html-tag',
+    },
+    {
+      include: '#component-tag',
+    },
+    {
+      include: '#html-comment',
+    },
+    {
+      include: '#entities',
+    },
+  ],
+  repository: {
+    'glimmer-component-path': {
+      match: '(::|\\$|\\.)',
+      captures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+      },
+    },
+    'string-double-quoted-handlebars': {
+      name: 'string.quoted.double.ember-handlebars',
+      begin: '"',
+      beginCaptures: {
+        0: {
+          name: 'punctuation.definition.string.begin.ember-handlebars',
+        },
+      },
+      end: '"',
+      endCaptures: {
+        0: {
+          name: 'punctuation.definition.string.end.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          name: 'constant.character.escape.ember-handlebars',
+          match: '\\\\"',
+        },
+      ],
+    },
+    'string-single-quoted-handlebars': {
+      name: 'string.quoted.single.ember-handlebars',
+      begin: "'",
+      beginCaptures: {
+        0: {
+          name: 'punctuation.definition.string.begin.ember-handlebars',
+        },
+      },
+      end: "'",
+      endCaptures: {
+        0: {
+          name: 'punctuation.definition.string.end.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          name: 'constant.character.escape.ember-handlebars',
+          match: "\\\\'",
+        },
+      ],
+    },
+    'string-double-quoted-html': {
+      name: 'string.quoted.double.html.ember-handlebars',
+      begin: '"',
+      beginCaptures: {
+        0: {
+          name: 'punctuation.definition.string.begin.ember-handlebars',
+        },
+      },
+      end: '"',
+      endCaptures: {
+        0: {
+          name: 'punctuation.definition.string.end.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          name: 'constant.character.escape.ember-handlebars',
+          match: '\\\\"',
+        },
+        {
+          include: '#glimmer-bools',
+        },
+        {
+          include: '#glimmer-expression-property',
+        },
+        {
+          include: '#glimmer-control-expression',
+        },
+        {
+          include: '#glimmer-expression',
+        },
+        {
+          include: '#glimmer-block',
+        },
+      ],
+    },
+    'string-single-quoted-html': {
+      name: 'string.quoted.single.html.ember-handlebars',
+      begin: "'",
+      beginCaptures: {
+        0: {
+          name: 'punctuation.definition.string.begin.ember-handlebars',
+        },
+      },
+      end: "'",
+      endCaptures: {
+        0: {
+          name: 'punctuation.definition.string.end.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          name: 'constant.character.escape.ember-handlebars',
+          match: "\\\\'",
+        },
+        {
+          include: '#glimmer-bools',
+        },
+        {
+          include: '#glimmer-expression-property',
+        },
+        {
+          include: '#glimmer-control-expression',
+        },
+        {
+          include: '#glimmer-expression',
+        },
+        {
+          include: '#glimmer-block',
+        },
+      ],
+    },
+    'boolean': {
+      match: 'true|false|undefined|null',
+      captures: {
+        0: {
+          name: 'string.regexp',
+        },
+        1: {
+          name: 'string.regexp',
+        },
+        2: {
+          name: 'string.regexp',
+        },
+      },
+      patterns: [],
+    },
+    'digit': {
+      match: '\\d*(\\.)?\\d+',
+      captures: {
+        0: {
+          name: 'constant.numeric',
+        },
+        1: {
+          name: 'constant.numeric',
+        },
+        2: {
+          name: 'constant.numeric',
+        },
+      },
+      patterns: [],
+    },
+    'param': {
+      match: '(@|this.)([a-zA-Z0-9_.-]+)',
+      captures: {
+        0: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'variable.language',
+              match: '(@|this)',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+        1: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+      },
+      patterns: [],
+    },
+    'attention': {
+      name: 'storage.type.class.${1:/downcase}',
+      match: '@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|TEMP)\\b',
+      patterns: [],
+    },
+    'glimmer-unescaped-expression': {
+      name: 'entity.unescaped.expression.ember-handlebars',
+      begin: '{{{',
+      end: '}}}',
+      captures: {
+        0: {
+          name: 'keyword.operator',
+        },
+      },
+      patterns: [
+        {
+          include: '#string-single-quoted-handlebars',
+        },
+        {
+          include: '#string-double-quoted-handlebars',
+        },
+        {
+          include: '#glimmer-subexp',
+        },
+        {
+          include: '#param',
+        },
+      ],
+    },
+    'glimmer-comment-block': {
+      name: 'comment.block.glimmer',
+      begin: '{{!--',
+      end: '--}}',
+      captures: {
+        0: {
+          name: 'punctuation.definition.block.comment.glimmer',
+        },
+      },
+      patterns: [
+        {
+          include: '#script',
+        },
+        {
+          include: '#attention',
+        },
+      ],
+    },
+    'glimmer-comment-inline': {
+      name: 'comment.inline.glimmer',
+      begin: '{{!',
+      end: '}}',
+      captures: {
+        0: {
+          name: 'punctuation.definition.block.comment.glimmer',
+        },
+      },
+      patterns: [
+        {
+          include: '#script',
+        },
+        {
+          include: '#attention',
+        },
+      ],
+    },
+    'glimmer-bools': {
+      name: 'entity.expression.ember-handlebars',
+      match: '({{~?)(true|false|null|undefined|\\d*(\\.)?\\d+)(~?}})',
+      captures: {
+        0: {
+          name: 'keyword.operator',
+        },
+        1: {
+          name: 'keyword.operator',
+        },
+        2: {
+          name: 'string.regexp',
+        },
+        3: {
+          name: 'string.regexp',
+        },
+        4: {
+          name: 'keyword.operator',
+        },
+      },
+    },
+    'glimmer-else-block': {
+      name: 'entity.expression.ember-handlebars',
+      match: '({{~?)(else\\s[a-z]+\\s|else)([()@a-zA-Z0-9\\.\\s\\b]+)?(~?}})',
+      captures: {
+        0: {
+          name: 'punctuation.definition.tag',
+        },
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'keyword.control',
+        },
+        3: {
+          name: 'keyword.control',
+          patterns: [
+            {
+              include: '#glimmer-subexp',
+            },
+            {
+              include: '#string-single-quoted-handlebars',
+            },
+            {
+              include: '#string-double-quoted-handlebars',
+            },
+            {
+              include: '#boolean',
+            },
+            {
+              include: '#digit',
+            },
+            {
+              include: '#param',
+            },
+            {
+              include: '#glimmer-parameter-name',
+            },
+            {
+              include: '#glimmer-parameter-value',
+            },
+          ],
+        },
+        4: {
+          name: 'punctuation.definition.tag',
+        },
+      },
+    },
+    'glimmer-special-block': {
+      name: 'entity.expression.ember-handlebars',
+      match: '({{~?)(yield|outlet)(~?}})',
+      captures: {
+        0: {
+          name: 'keyword.operator',
+        },
+        1: {
+          name: 'keyword.operator',
+        },
+        2: {
+          name: 'keyword.control',
+        },
+        3: {
+          name: 'keyword.operator',
+        },
+      },
+    },
+    'glimmer-as-stuff': {
+      patterns: [
+        {
+          include: '#as-keyword',
+        },
+        {
+          include: '#as-params',
+        },
+      ],
+    },
+    'glimmer-block': {
+      name: 'entity.expression.ember-handlebars',
+      begin: '({{~?)(#|/)(([@\\$a-zA-Z0-9_/.-]+))',
+      end: '(~?}})',
+      captures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'punctuation.definition.tag',
+        },
+        3: {
+          name: 'keyword.control',
+          patterns: [
+            {
+              include: '#glimmer-component-path',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\/)+',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+      },
+      patterns: [
+        {
+          include: '#glimmer-as-stuff',
+        },
+        {
+          include: '#glimmer-supexp-content',
+        },
+      ],
+    },
+    'glimmer-expression-property': {
+      name: 'entity.expression.ember-handlebars',
+      begin: '({{~?)((@|this.)([a-zA-Z0-9_.-]+))',
+      end: '(~?}})',
+      captures: {
+        1: {
+          name: 'keyword.operator',
+        },
+        2: {
+          name: 'keyword.operator',
+        },
+        3: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'variable.language',
+              match: '(@|this)',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+        4: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+      },
+      patterns: [
+        {
+          include: '#glimmer-supexp-content',
+        },
+      ],
+    },
+    'glimmer-expression': {
+      name: 'entity.expression.ember-handlebars',
+      begin: '({{~?)(([()\\s@a-zA-Z0-9_.-]+))',
+      end: '(~?}})',
+      captures: {
+        1: {
+          name: 'keyword.operator',
+        },
+        2: {
+          name: 'keyword.operator',
+        },
+        3: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'string.regexp',
+              match: '[(]+',
+            },
+            {
+              name: 'string.regexp',
+              match: '[)]+',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+            {
+              include: '#glimmer-supexp-content',
+            },
+          ],
+        },
+      },
+      patterns: [
+        {
+          include: '#glimmer-supexp-content',
+        },
+      ],
+    },
+    'glimmer-supexp-content': {
+      patterns: [
+        {
+          include: '#glimmer-subexp',
+        },
+        {
+          include: '#string-single-quoted-handlebars',
+        },
+        {
+          include: '#string-double-quoted-handlebars',
+        },
+        {
+          include: '#boolean',
+        },
+        {
+          include: '#digit',
+        },
+        {
+          include: '#param',
+        },
+        {
+          include: '#glimmer-parameter-name',
+        },
+        {
+          include: '#glimmer-parameter-value',
+        },
+      ],
+    },
+    'glimmer-control-expression': {
+      name: 'entity.expression.ember-handlebars',
+      begin: '({{~?)(([-a-z/]+)\\s)',
+      end: '(~?}})',
+      captures: {
+        1: {
+          name: 'keyword.operator',
+        },
+        2: {
+          name: 'keyword.operator',
+        },
+        3: {
+          name: 'keyword.control',
+        },
+      },
+      patterns: [
+        {
+          include: '#glimmer-supexp-content',
+        },
+      ],
+    },
+    'glimmer-subexp': {
+      name: 'entity.subexpression.ember-handlebars',
+      begin: '(\\()([@a-zA-Z0-9.-]+)',
+      end: '(\\))',
+      captures: {
+        1: {
+          name: 'keyword.other',
+        },
+        2: {
+          name: 'keyword.control',
+        },
+      },
+      patterns: [
+        {
+          include: '#glimmer-supexp-content',
+        },
+      ],
+    },
+    'as-keyword': {
+      name: 'keyword.control',
+      match: '\\s\\b(as)\\b(?=\\s\\|)',
+      patterns: [],
+    },
+    'as-params': {
+      name: 'keyword.block-params.ember-handlebars',
+      begin: '(?<!\\|)(\\|)',
+      beginCaptures: {
+        1: {
+          name: 'constant.other.symbol.begin.ember-handlebars',
+        },
+      },
+      end: '(\\|)(?!\\|)',
+      endCaptures: {
+        1: {
+          name: 'constant.other.symbol.end.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          include: '#variable',
+        },
+      ],
+    },
+    'glimmer-parameter-value': {
+      match: '\\b([a-zA-Z0-9:_.-]+)\\b(?!=)',
+      captures: {
+        1: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+      },
+      patterns: [],
+    },
+    'glimmer-parameter-name': {
+      match: '\\b([a-zA-Z0-9_-]+)(\\s?=)',
+      captures: {
+        1: {
+          name: 'variable.parameter.name.ember-handlebars',
+        },
+        2: {
+          name: 'punctuation.definition.expression.ember-handlebars',
+        },
+      },
+      patterns: [],
+    },
+    'variable': {
+      name: 'support.function',
+      match: '\\b([a-zA-Z0-9-_]+)\\b',
+      patterns: [],
+    },
+    'style': {
+      begin: '(^[ \\t]+)?(?=<(?i:style)\\b(?!-))',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.whitespace.embedded.leading.html',
+        },
+      },
+      end: '(?!\\G)([ \\t]*$\\n?)?',
+      endCaptures: {
+        1: {
+          name: 'punctuation.whitespace.embedded.trailing.html',
+        },
+      },
+      patterns: [
+        {
+          begin: '(?i)(<)(style)(?=\\s|/?>)',
+          beginCaptures: {
+            0: {
+              name: 'meta.tag.metadata.style.start.html',
+            },
+            1: {
+              name: 'punctuation.definition.tag.begin.html',
+            },
+            2: {
+              name: 'entity.name.tag.html',
+            },
+          },
+          end: '(?i)((<)/)(style)\\s*(>)',
+          endCaptures: {
+            0: {
+              name: 'meta.tag.metadata.style.end.html',
+            },
+            1: {
+              name: 'punctuation.definition.tag.begin.html',
+            },
+            2: {
+              name: 'source.css-ignored-vscode',
+            },
+            3: {
+              name: 'entity.name.tag.html',
+            },
+            4: {
+              name: 'punctuation.definition.tag.end.html',
+            },
+          },
+          name: 'meta.embedded.block.html',
+          patterns: [
+            {
+              begin: '\\G',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.tag.end.html',
+                },
+              },
+              end: '(>)',
+              name: 'meta.tag.metadata.style.start.html',
+              patterns: [
+                {
+                  include: '#glimmer-argument',
+                },
+                {
+                  include: '#html-attribute',
+                },
+              ],
+            },
+            {
+              begin: '(?!\\G)',
+              end: '(?=</(?i:style))',
+              name: 'source.css',
+              patterns: [
+                {
+                  include: 'source.css',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    'script': {
+      begin: '(^[ \\t]+)?(?=<(?i:script)\\b(?!-))',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.whitespace.embedded.leading.html',
+        },
+      },
+      end: '(?!\\G)([ \\t]*$\\n?)?',
+      endCaptures: {
+        1: {
+          name: 'punctuation.whitespace.embedded.trailing.html',
+        },
+      },
+      patterns: [
+        {
+          begin: '(<)((?i:script))\\b',
+          beginCaptures: {
+            0: {
+              name: 'meta.tag.metadata.script.start.html',
+            },
+            1: {
+              name: 'punctuation.definition.tag.begin.html',
+            },
+            2: {
+              name: 'entity.name.tag.html',
+            },
+          },
+          end: '(/)((?i:script))(>)',
+          endCaptures: {
+            0: {
+              name: 'meta.tag.metadata.script.end.html',
+            },
+            1: {
+              name: 'punctuation.definition.tag.begin.html',
+            },
+            2: {
+              name: 'entity.name.tag.html',
+            },
+            3: {
+              name: 'punctuation.definition.tag.end.html',
+            },
+          },
+          name: 'meta.embedded.block.html',
+          patterns: [
+            {
+              begin: '\\G',
+              end: '(?=/)',
+              patterns: [
+                {
+                  begin: '(>)',
+                  beginCaptures: {
+                    0: {
+                      name: 'meta.tag.metadata.script.start.html',
+                    },
+                    1: {
+                      name: 'punctuation.definition.tag.end.html',
+                    },
+                  },
+                  end: '((<))(?=/(?i:script))',
+                  endCaptures: {
+                    0: {
+                      name: 'meta.tag.metadata.script.end.html',
+                    },
+                    1: {
+                      name: 'punctuation.definition.tag.begin.html',
+                    },
+                    2: {
+                      name: 'source.js-ignored-vscode',
+                    },
+                  },
+                  patterns: [
+                    {
+                      begin: '\\G',
+                      end: '(?=</(?i:script))',
+                      name: 'source.js',
+                      patterns: [
+                        {
+                          begin: '(^[ \\t]+)?(?=//)',
+                          beginCaptures: {
+                            1: {
+                              name: 'punctuation.whitespace.comment.leading.js',
+                            },
+                          },
+                          end: '(?!\\G)',
+                          patterns: [
+                            {
+                              begin: '//',
+                              beginCaptures: {
+                                0: {
+                                  name: 'punctuation.definition.comment.js',
+                                },
+                              },
+                              end: '(?=</script)|\\n',
+                              name: 'comment.line.double-slash.js',
+                            },
+                          ],
+                        },
+                        {
+                          begin: '/\\*',
+                          captures: {
+                            0: {
+                              name: 'punctuation.definition.comment.js',
+                            },
+                          },
+                          end: '\\*/|(?=</script)',
+                          name: 'comment.block.js',
+                        },
+                        {
+                          include: 'source.js',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  begin:
+                    '(?ix:\n\t\t\t\t\t\t\t\t\t\t\t\t(?=\n\t\t\t\t\t\t\t\t\t\t\t\t\ttype\\s*=\\s*\n\t\t\t\t\t\t\t\t\t\t\t\t\t(\'|"|)\n\t\t\t\t\t\t\t\t\t\t\t\t\ttext/\n\t\t\t\t\t\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tx-handlebars\n\t\t\t\t\t\t\t\t\t\t\t\t\t  | (x-(handlebars-)?|ng-)?template\n\t\t\t\t\t\t\t\t\t\t\t\t\t  | html\n\t\t\t\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\\s"\'>]\n\t\t\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t\t\t)',
+                  end: '((<))(?=/(?i:script))',
+                  endCaptures: {
+                    0: {
+                      name: 'meta.tag.metadata.script.end.html',
+                    },
+                    1: {
+                      name: 'punctuation.definition.tag.begin.html',
+                    },
+                    2: {
+                      name: 'text.html.basic',
+                    },
+                  },
+                  patterns: [
+                    {
+                      begin: '(?!\\G)',
+                      end: '(?=</(?i:script))',
+                      name: 'text.html.basic',
+                      patterns: [
+                        {
+                          include: 'text.html.basic',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  begin: '(?=(?i:type))',
+                  end: '(<)(?=/(?i:script))',
+                  endCaptures: {
+                    0: {
+                      name: 'meta.tag.metadata.script.end.html',
+                    },
+                    1: {
+                      name: 'punctuation.definition.tag.begin.html',
+                    },
+                  },
+                },
+                {
+                  include: '#string-double-quoted-html',
+                },
+                {
+                  include: '#string-single-quoted-html',
+                },
+                {
+                  include: '#glimmer-argument',
+                },
+                {
+                  include: '#html-attribute',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    'html-comment': {
+      name: 'comment.block.html.ember-handlebars',
+      begin: '<!--',
+      end: '--\\s*>',
+      captures: {
+        0: {
+          name: 'punctuation.definition.comment.html.ember-handlebars',
+        },
+      },
+      patterns: [
+        {
+          include: '#attention',
+        },
+        {
+          match: '--',
+          name: 'invalid.illegal.bad-comments-or-CDATA.html.ember-handlebars',
+        },
+      ],
+    },
+    'tag-like-content': {
+      patterns: [
+        {
+          include: '#glimmer-bools',
+        },
+        {
+          include: '#glimmer-unescaped-expression',
+        },
+        {
+          include: '#glimmer-comment-block',
+        },
+        {
+          include: '#glimmer-comment-inline',
+        },
+        {
+          include: '#glimmer-expression-property',
+        },
+        {
+          include: '#boolean',
+        },
+        {
+          include: '#digit',
+        },
+        {
+          include: '#glimmer-control-expression',
+        },
+        {
+          include: '#glimmer-expression',
+        },
+        {
+          include: '#glimmer-block',
+        },
+        {
+          include: '#string-double-quoted-html',
+        },
+        {
+          include: '#string-single-quoted-html',
+        },
+        {
+          include: '#glimmer-as-stuff',
+        },
+        {
+          include: '#glimmer-argument',
+        },
+        {
+          include: '#html-attribute',
+        },
+      ],
+    },
+    'component-tag': {
+      name: 'meta.tag.any.ember-handlebars',
+      begin: '(<\\/?)(@|this.)?([a-zA-Z0-9-\\$:\\.]+)\\b',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'support.function',
+          patterns: [
+            {
+              name: 'variable.language',
+              match: '(@|this)',
+            },
+            {
+              name: 'punctuation.definition.tag',
+              match: '(\\.)+',
+            },
+          ],
+        },
+        3: {
+          name: 'entity.name.type',
+          patterns: [
+            {
+              include: '#glimmer-component-path',
+            },
+            {
+              name: 'markup.bold',
+              match: '(@|:|\\$)',
+            },
+          ],
+        },
+      },
+      end: '(\\/?)(>)',
+      endCaptures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'punctuation.definition.tag',
+        },
+      },
+      patterns: [
+        {
+          include: '#tag-like-content',
+        },
+      ],
+    },
+    'html-tag': {
+      name: 'meta.tag.any.ember-handlebars',
+      begin: '(<\\/?)([a-z0-9-]+)(?!\\.|:)\\b',
+      beginCaptures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'entity.name.tag.html.ember-handlebars',
+        },
+      },
+      end: '(\\/?)(>)',
+      endCaptures: {
+        1: {
+          name: 'punctuation.definition.tag',
+        },
+        2: {
+          name: 'punctuation.definition.tag',
+        },
+      },
+      patterns: [
+        {
+          include: '#tag-like-content',
+        },
+      ],
+    },
+    'glimmer-argument': {
+      match: '\\s(@[a-zA-Z0-9:_.-]+)(=)?',
+      captures: {
+        1: {
+          name: 'entity.other.attribute-name.ember-handlebars.argument',
+          patterns: [
+            {
+              name: 'markup.italic',
+              match: '(@)',
+            },
+          ],
+        },
+        2: {
+          name: 'punctuation.separator.key-value.html.ember-handlebars',
+        },
+      },
+    },
+    'html-attribute': {
+      match: '\\s([a-zA-Z0-9:_.-]+)(=)?',
+      captures: {
+        1: {
+          name: 'entity.other.attribute-name.ember-handlebars',
+          patterns: [
+            {
+              name: 'markup.bold',
+              match: '(\\.\\.\\.attributes)',
+            },
+          ],
+        },
+        2: {
+          name: 'punctuation.separator.key-value.html.ember-handlebars',
+        },
+      },
+    },
+    'entities': {
+      patterns: [
+        {
+          name: 'constant.character.entity.html.ember-handlebars',
+          match: '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)',
+          captures: {
+            1: {
+              name: 'punctuation.definition.entity.html.ember-handlebars',
+            },
+            3: {
+              name: 'punctuation.definition.entity.html.ember-handlebars',
+            },
+          },
+        },
+        {
+          name: 'invalid.illegal.bad-ampersand.html.ember-handlebars',
+          match: '&',
+        },
+      ],
+    },
+  },
+};

--- a/syntaxes/text.html.ember-handlebars.json
+++ b/syntaxes/text.html.ember-handlebars.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Glimmer",
   "scopeName": "text.html.ember-handlebars",
-  "fileTypes": ["hbs"],
+  "fileTypes": [
+    "hbs"
+  ],
   "patterns": [
     {
       "include": "#style"


### PR DESCRIPTION
I've added a `src` directory to the `syntaxes` directory that contains the individual grammar definitions as JS objects. 

The `index.mjs` files does the build where we merge the `inline.template` and `inline.hbs` grammars into the `glimmer js` and `glimmer ts` grammars.

I renamed the grammars to match their scope name.

I added a readme to the `syntaxes` directory to warn people not the edit the json directly.

I've added a build step to the workflow which should run the `index.mjs` file to build the grammars and commit the resulting json back to the repo. It can also be run manually by running `yarn build:grammars`.

I've tested this in VSCode and in NovaLightshow.