### PR TITLE
Remove unnecessary injection from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,10 @@
         "path": "./syntaxes/source.gjs.json",
         "scopeName": "source.gjs",
         "embeddedLanguages": {
-          "source.gjs": "javascript"
+          "source.gjs": "javascript",
+          "meta.embedded.block.html": "handlebars",
+          "meta.js.embeddedTemplateWithoutArgs": "handlebars",
+          "meta.js.embeddedTemplateWithArgs": "handlebars"
         },
         "unbalancedBracketScopes": [
           "keyword.operator.relational",
@@ -119,7 +122,10 @@
         "path": "./syntaxes/source.gts.json",
         "scopeName": "source.gts",
         "embeddedLanguages": {
-          "source.gts": "typescript"
+          "source.gts": "typescript",
+          "meta.embedded.block.html": "handlebars",
+          "meta.js.embeddedTemplateWithoutArgs": "handlebars",
+          "meta.js.embeddedTemplateWithArgs": "handlebars"
         },
         "unbalancedBracketScopes": [
           "keyword.operator.relational",
@@ -145,19 +151,6 @@
         "path": "./syntaxes/inline.hbs.json",
         "embeddedLanguages": {
           "meta.embedded.block.html": "handlebars"
-        }
-      },
-      {
-        "injectTo": [
-          "source.gts",
-          "source.gjs"
-        ],
-        "scopeName": "inline.template",
-        "path": "./syntaxes/inline.template.json",
-        "embeddedLanguages": {
-          "meta.embedded.block.html": "handlebars",
-          "meta.js.embeddedTemplateWithoutArgs": "handlebars",
-          "meta.js.embeddedTemplateWithArgs": "handlebars"
         }
       }
     ],


### PR DESCRIPTION
Now that inline.template is injected to source.gjs/gts at build time we don't need to instruct vscode to do this from the package.json.

We do need to set the embeddedLanguages in the glimmer-ts and glimmer-js definitions to ensure the language configurations take effect.