### PR TITLE
adds underscore to the glimmer component-tag regex

### DIFF
--- a/syntaxes/src/text.html.ember-handlebars.mjs
+++ b/syntaxes/src/text.html.ember-handlebars.mjs
@@ -55,7 +55,7 @@ export default {
   ],
   repository: {
     'glimmer-component-path': {
-      match: '(::|\\$|\\.)',
+      match: '(::|_|\\$|\\.)',
       captures: {
         1: {
           name: 'punctuation.definition.tag',
@@ -955,7 +955,7 @@ export default {
     },
     'component-tag': {
       name: 'meta.tag.any.ember-handlebars',
-      begin: '(<\\/?)(@|this.)?([a-zA-Z0-9-\\$:\\.]+)\\b',
+      begin: '(<\\/?)(@|this.)?([a-zA-Z0-9-_\\$:\\.]+)\\b',
       beginCaptures: {
         1: {
           name: 'punctuation.definition.tag',

--- a/syntaxes/text.html.ember-handlebars.json
+++ b/syntaxes/text.html.ember-handlebars.json
@@ -57,7 +57,7 @@
   ],
   "repository": {
     "glimmer-component-path": {
-      "match": "(::|\\$|\\.)",
+      "match": "(::|_|\\$|\\.)",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag"
@@ -956,7 +956,7 @@
     },
     "component-tag": {
       "name": "meta.tag.any.ember-handlebars",
-      "begin": "(<\\/?)(@|this.)?([a-zA-Z0-9-\\$:\\.]+)\\b",
+      "begin": "(<\\/?)(@|this.)?([a-zA-Z0-9-_\\$:\\.]+)\\b",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag"


### PR DESCRIPTION
treat underscores same as component paths for highlighting purposes
fixes https://github.com/lifeart/vsc-ember-syntax/issues/58