### PR TITLE
Unstringify tagged templates

### DIFF
--- a/syntaxes/inline.hbs.json
+++ b/syntaxes/inline.hbs.json
@@ -16,7 +16,6 @@
   },
   "patterns": [
     {
-      "name": "string.js.taggedTemplate",
       "contentName": "meta.embedded.block.html",
       "begin": "(?x)(\\b(?:\\w+\\.)*(?:hbs|html)\\s*)(`)",
       "beginCaptures": {
@@ -67,7 +66,7 @@
       },
       "patterns": [
         {
-          "begin": "((`))",
+          "begin": "((`|'|\"))",
           "beginCaptures": {
             "1": {
               "name": "string.template.ts"
@@ -76,7 +75,7 @@
               "name": "punctuation.definition.string.template.begin.ts"
             }
           },
-          "end": "((`))",
+          "end": "((`|'|\"))",
           "endCaptures": {
             "1": {
               "name": "string.template.ts"

--- a/syntaxes/src/inline.hbs.mjs
+++ b/syntaxes/src/inline.hbs.mjs
@@ -13,7 +13,6 @@ export default {
   },
   patterns: [
     {
-      name: 'string.js.taggedTemplate',
       contentName: 'meta.embedded.block.html',
       begin: '(?x)(\\b(?:\\w+\\.)*(?:hbs|html)\\s*)(`)',
       beginCaptures: {
@@ -64,7 +63,7 @@ export default {
       },
       patterns: [
         {
-          begin: '((`))',
+          begin: '((`|\'|"))',
           beginCaptures: {
             1: {
               name: 'string.template.ts',
@@ -73,7 +72,7 @@ export default {
               name: 'punctuation.definition.string.template.begin.ts',
             },
           },
-          end: '((`))',
+          end: '((`|\'|"))',
           endCaptures: {
             1: {
               name: 'string.template.ts',


### PR DESCRIPTION
Removing `name: 'string.js.taggedTemplate'` ensures the text in the hbs/html tagged templates is not highlighted as a JS string (so it's not blue).

```js
hbs`<div>thing</div>`
html`<div>thing</div>`
```

And for the function usage of `createTemplate`, `hbs`, `html` changing the ```((`))``` capture to ```((`|\'|"))``` ensures no matter what quote style you use it highlights correctly.

These together make all these variants highlight in the same way

<img width="498" alt="image" src="https://github.com/lifeart/vsc-ember-syntax/assets/83799/5c93f6e0-7685-4141-9977-b2f1f1826e67">
