### PR TITLE
WIP: Update license format

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,8 @@
+MIT License
+
 Copyright (c) 2021 Aleksandr Kanunnikov, and contributors.
 
-All rights reserved. 
-
-MIT License
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I'm working on Shiki support using the grammars defined here. It pulls the license file and determines what license it is by reading the first line. I've moved `MIT License` to the top so it can determine the license type properly.