### PR TITLE
Fix: Fix GitHub and original textmate when using undeclared default export of a template in GTS/GJS

### DIFF
--- a/syntaxes/source.gjs.json
+++ b/syntaxes/source.gjs.json
@@ -4,10 +4,10 @@
   "scopeName": "source.gjs",
   "patterns": [
     {
-      "include": "source.js"
+      "include": "#main"
     },
     {
-      "include": "#main"
+      "include": "source.js"
     }
   ],
   "injections": {

--- a/syntaxes/source.gts.json
+++ b/syntaxes/source.gts.json
@@ -4,10 +4,10 @@
   "scopeName": "source.gts",
   "patterns": [
     {
-      "include": "source.ts"
+      "include": "#main"
     },
     {
-      "include": "#main"
+      "include": "source.ts"
     }
   ],
   "injections": {

--- a/syntaxes/src/index.mjs
+++ b/syntaxes/src/index.mjs
@@ -29,7 +29,7 @@ function mergeGlimmerSourceGrammars(grammar, injectionSelector) {
     },
   };
 
-  grammar.patterns.push({ include: '#main' });
+  grammar.patterns.unshift({ include: '#main' });
 
   grammar.repository = {
     main: {


### PR DESCRIPTION
Apparently the order of the patterns array matters a lot to textmate. GitHub seems to closely match the original textmate highlighting engine compared to any other implementation (which were highlighting correctly without this)

@lifeart don't merge this until I've tested shikijs, I want to ensure this fix isn't breaking everywhere else this is used.

I'll post a reply once I'm happy everywhere is working as intended.