### PR TITLE
feat: highlight component tag as HTML entity

### DIFF
--- a/syntaxes/source.gjs.json
+++ b/syntaxes/source.gjs.json
@@ -1381,7 +1381,7 @@
           ]
         },
         "3": {
-          "name": "entity.name.type",
+          "name": "entity.name.tag.html",
           "patterns": [
             {
               "include": "#glimmer-component-path"

--- a/syntaxes/source.gts.json
+++ b/syntaxes/source.gts.json
@@ -1381,7 +1381,7 @@
           ]
         },
         "3": {
-          "name": "entity.name.type",
+          "name": "entity.name.tag.html",
           "patterns": [
             {
               "include": "#glimmer-component-path"

--- a/syntaxes/src/text.html.ember-handlebars.mjs
+++ b/syntaxes/src/text.html.ember-handlebars.mjs
@@ -974,7 +974,7 @@ export default {
           ],
         },
         3: {
-          name: 'entity.name.type',
+          name: 'entity.name.tag.html',
           patterns: [
             {
               include: '#glimmer-component-path',

--- a/syntaxes/text.html.ember-handlebars.json
+++ b/syntaxes/text.html.ember-handlebars.json
@@ -975,7 +975,7 @@
           ]
         },
         "3": {
-          "name": "entity.name.type",
+          "name": "entity.name.tag.html",
           "patterns": [
             {
               "include": "#glimmer-component-path"


### PR DESCRIPTION
Origin: https://discord.com/channels/480462759797063690/518154533143183377/1218860748227481671

Open this PR for discussion!

GitHub syntax highlighting:

| HBS | GJS |
| --- | --- |
| ![image](https://github.com/lifeart/vsc-ember-syntax/assets/10243652/82de7772-8414-4f47-aff4-fe3267a57a41) | ![image](https://github.com/lifeart/vsc-ember-syntax/assets/10243652/12707d15-be3d-4a37-bf70-603183945c1f) |

My main readability issues:
1. In .gjs, component invocations are highlighted as value, which makes sense because that's what it is in the language. However, I feel like the highlighting as DOM node in hbs provides more clarity/contrast. (this is also how Vue does it, haven't checked other languages)
2. Braces {{ ... }} are highlighted in red. This feels to me like it's an error in the code. The coloring in hbs seems nicer here.

Adapting the first point:

| Before | After |
| --- | --- |
| <img width="418" alt="image" src="https://github.com/lifeart/vsc-ember-syntax/assets/10243652/7889c24a-157a-41e7-807c-1d5a26b6b18d"> | <img width="419" alt="image" src="https://github.com/lifeart/vsc-ember-syntax/assets/10243652/89f6633d-c4ed-4b28-889e-3dac25e76112"> |

Now seeing that in action, not sure if it's an improvement in VS Code 🤔 
VS Code already does not reuse the same color for the component invocation name and the properties, which seems to be the main quirk on GitHub.